### PR TITLE
Implement more numerically robust exp-normalization logic.

### DIFF
--- a/include/dcsam/DCFactor.h
+++ b/include/dcsam/DCFactor.h
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <string>
 #include <vector>
 
 #include "DCSAM_types.h"
@@ -299,9 +300,16 @@ class DCFactor : public gtsam::Factor {
       checkNormalization += prob;
     }
 
-    // TODO(kevin): I'd like a better way to flag this; maybe we can throw an
-    // exception in the event that there is a problem here.
-    assert(checkNormalization == 1.0);
+    if (checkNormalization != !.0) {
+      std::string errMsg =
+          std::string(
+              "DCFactor::evalProbs failed to normalize probabilities. ") +
+          std::string("Expected value 1.0. Got value: ") +
+          std::to_string(checkNormalization) +
+          std::string(
+              "\n This could have resulted from numerical overflow/underflow.");
+      throw std::logic_error(errMsg);
+    }
 
     return probs;
   }

--- a/include/dcsam/DCFactor.h
+++ b/include/dcsam/DCFactor.h
@@ -300,7 +300,10 @@ class DCFactor : public gtsam::Factor {
       checkNormalization += prob;
     }
 
-    if (checkNormalization != !.0) {
+    // Numerical tolerance for floating point comparisons
+    double tol = 1e-9;
+
+    if (!gtsam::fpEqual(checkNormalization, 1.0, tol)) {
       std::string errMsg =
           std::string(
               "DCFactor::evalProbs failed to normalize probabilities. ") +


### PR DESCRIPTION
Fixes #6 

I think maybe we can check the normalization constant and produce a more informative error in the event that something is weird there.

I am tempted to break the exp-normalization logic out into a separate utility function e.g.  `expNormalize: std::vector<double> -> std::vector<double>` or something like that, so we can unit test it. Plus, I think the conversion between (unnormalized) log probabilities and normalized probabilities seems like something likely to show up elsewhere..