### PR TITLE
Expectation-maximization factors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,9 @@ find_package(Eigen3 3.3 REQUIRED)
 # add_definitions(-march=native)
 
 set(DCSAM_HDRS
-  include/dcsam/DCSAM.h
   include/dcsam/DCSAM_types.h
+  include/dcsam/DCSAM_utils.h
+  include/dcsam/DCSAM.h
   include/dcsam/DCFactor.h
   include/dcsam/DCContinuousFactor.h
   include/dcsam/DCDiscreteFactor.h
@@ -27,6 +28,7 @@ set(DCSAM_HDRS
   include/dcsam/SemanticBearingRangeFactor.h
   include/dcsam/SmartSemanticBearingRangeFactor.h
   include/dcsam/DCMaxMixtureFactor.h
+  include/dcsam/DCEMFactor.h
   )
 
 set(DCSAM_SRCS

--- a/include/dcsam/DCEMFactor.h
+++ b/include/dcsam/DCEMFactor.h
@@ -1,0 +1,194 @@
+/**
+ * @file DCEMFactor.h
+ * @brief Discrete-Continuous EM factor
+ * @author Kevin Doherty, kdoherty@mit.edu
+ * Copyright 2021 The Ambitious Folks of the MRG
+ */
+
+#pragma once
+
+#include <math.h>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "dcsam/DCFactor.h"
+#include "dcsam/DCSAM_utils.h"
+
+namespace dcsam {
+
+/**
+ * @brief Implementation of a discrete-continuous EM factor
+ *
+ * The error function is defined as:
+ * r(x) = sum_i w'_i * r_i(x),
+ *
+ * where
+ * w'_i = w_i * p(z | x, l_i); sum_i w'_i = 1.
+ *
+ * The error returned from this factor is a weighted combination of the
+ * component factor errors.
+ */
+template <class DCFactorType>
+class DCEMFactor : public DCFactor {
+ private:
+  std::vector<DCFactorType> factors_;
+  std::vector<double> log_weights_;
+  bool normalized_;
+
+ public:
+  using Base = DCFactor;
+
+  DCEMFactor() = default;
+
+  explicit DCEMFactor(const gtsam::KeyVector& continuousKeys,
+                      const gtsam::DiscreteKeys& discreteKeys,
+                      const std::vector<DCFactorType> factors,
+                      const std::vector<double> weights, const bool normalized)
+      : Base(continuousKeys, discreteKeys), normalized_(normalized) {
+    factors_ = factors;
+    for (int i = 0; i < weights.size(); i++) {
+      log_weights_.push_back(log(weights[i]));
+    }
+  }
+
+  explicit DCEMFactor(const gtsam::KeyVector& continuousKeys,
+                      const gtsam::DiscreteKeys& discreteKeys,
+                      const std::vector<DCFactorType> factors,
+                      const bool normalized)
+      : Base(continuousKeys, discreteKeys), normalized_(normalized) {
+    factors_ = factors;
+    for (int i = 0; i < factors_.size(); i++) {
+      log_weights_.push_back(0);
+    }
+  }
+
+  DCEMFactor& operator=(const DCEMFactor& rhs) {
+    this->factors_ = rhs.factors_;
+    this->log_weights_ = rhs.log_weights_;
+    this->normalized_ = rhs.normalized_;
+  }
+
+  virtual ~DCEMFactor() = default;
+
+  double error(const gtsam::Values& continuousVals,
+               const DiscreteValues& discreteVals) const override {
+    // Retrieve the error for each component.
+    std::vector<double> errors =
+        computeComponentErrors(continuousVals, discreteVals);
+
+    // Weights for each component are obtained by normalizing the errors.
+    std::vector<double> componentWeights = expNormalize(errors);
+
+    // Compute the total error as the weighted sum of component errors.
+    double total_error = 0.0;
+    for (size_t i = 0; i < errors.size(); i++) {
+      total_error += componentWeights[i] * errors[i];
+    }
+    return total_error;
+  }
+
+  std::vector<double> computeComponentErrors(
+      const gtsam::Values& continuousVals,
+      const DiscreteValues& discreteVals) const {
+    // Container for errors, where:
+    //   error_i = error of component factor i - log_weights_i
+    std::vector<double> errors;
+    for (int i = 0; i < factors_.size(); i++) {
+      double error =
+          factors_[i].error(continuousVals, discreteVals) - log_weights_[i];
+      if (!normalized_)
+        error += factors_[i].logNormalizingConstant(continuousVals);
+      errors.push_back(error);
+    }
+    return errors;
+  }
+
+  size_t getActiveFactorIdx(const gtsam::Values& continuousVals,
+                            const DiscreteValues& discreteVals) const {
+    double min_error = std::numeric_limits<double>::infinity();
+    size_t min_error_idx;
+    for (int i = 0; i < factors_.size(); i++) {
+      double error =
+          factors_[i].error(continuousVals, discreteVals) - log_weights_[i];
+      if (!normalized_)
+        error += factors_[i].logNormalizingConstant(continuousVals);
+
+      if (error < min_error) {
+        min_error = error;
+        min_error_idx = i;
+      }
+    }
+    return min_error_idx;
+  }
+
+  // TODO(kevin) Need to adjust Jacobian size!
+  size_t dim() const override {
+    if (factors_.size() > 0) {
+      return factors_[0].dim();
+    } else {
+      return 0;
+    }
+  }
+
+  bool equals(const DCFactor& other, double tol = 1e-9) const {
+    if (!dynamic_cast<const DCEMFactor*>(&other)) return false;
+    const DCEMFactor& f(static_cast<const DCEMFactor&>(other));
+    if (factors_.size() != f.factors_.size()) return false;
+    for (size_t i = 0; i < factors_.size(); i++) {
+      if (!factors_[i].equals(f.factors_[i])) return false;
+    }
+    return ((log_weights_ == f.log_weights_) && (normalized_ == f.normalized_));
+  }
+
+  // TODO(kevin) Need to adjust linearization!
+  boost::shared_ptr<gtsam::GaussianFactor> linearize(
+      const gtsam::Values& continuousVals,
+      const DiscreteValues& discreteVals) const override {
+    std::vector<boost::shared_ptr<gtsam::GaussianFactor>> gfs;
+    // Create a set of matrices for all keys
+    std::vector<std::vector<gtsam::Matrix>> Hs;
+    // For each factor, compute the jacobian
+    for (const gtsam::Key& k : keys_) {
+      for (size_t i = 0; i < factors_.size(); i++) {
+        boost::shared_ptr<gtsam::GaussianFactor> gf =
+            factors_[i].linearize(continuousVals, discreteVals);
+        // for each key in factor keys, get the appropriate jacobian and add it
+        // to the stack?
+        std::pair<gtsam::Matrix, gtsam::Vector> jacobianAb = gf->jacobian();
+      }
+    }
+    // Stack Jacobians
+    size_t min_error_idx = getActiveFactorIdx(continuousVals, discreteVals);
+    return factors_[min_error_idx].linearize(continuousVals, discreteVals);
+  }
+
+  gtsam::DecisionTreeFactor toDecisionTreeFactor(
+      const gtsam::Values& continuousVals,
+      const DiscreteValues& discreteVals) const override {
+    size_t min_error_idx = getActiveFactorIdx(continuousVals, discreteVals);
+    return factors_[min_error_idx].toDecisionTreeFactor(continuousVals,
+                                                        discreteVals);
+  }
+
+  gtsam::FastVector<gtsam::Key> getAssociationKeys(
+      const gtsam::Values& continuousVals,
+      const DiscreteValues& discreteVals) const {
+    size_t min_error_idx = getActiveFactorIdx(continuousVals, discreteVals);
+    return factors_[min_error_idx].keys();
+  }
+
+  void updateWeights(const std::vector<double>& weights) {
+    if (weights.size() != log_weights_.size()) {
+      std::cerr << "Attempted to update weights with incorrectly sized vector."
+                << std::endl;
+      return;
+    }
+    for (int i = 0; i < weights.size(); i++) {
+      log_weights_[i] = log(weights[i]);
+    }
+  }
+};
+}  // namespace dcsam

--- a/include/dcsam/DCEMFactor.h
+++ b/include/dcsam/DCEMFactor.h
@@ -156,9 +156,6 @@ class DCEMFactor : public DCFactor {
       const DiscreteValues& discreteVals) const override {
     std::vector<boost::shared_ptr<gtsam::GaussianFactor>> gfs;
 
-    // Create a set of matrices for all keys
-    std::vector<std::vector<gtsam::Matrix>> Hs;
-
     // Start by computing all errors, so we can get the component weights.
     std::vector<double> errors =
         computeComponentErrors(continuousVals, discreteVals);
@@ -188,6 +185,12 @@ class DCEMFactor : public DCFactor {
       // Passing `appendOneDimension=true` adds a dimension for the `b` vector
       // automatically.
       gtsam::VerticalBlockMatrix Ab(dimensions, factors_[i].dim(), true);
+
+      // Populate Ab with weighted Jacobian sqrt(w)*A and right-hand side vector
+      // sqrt(w)*b.
+      double sqrt_weight = sqrt(componentWeights[i]);
+      Ab(0) = sqrt_weight * jacobianAb.first;
+      Ab(1) = sqrt_weight * jacobianAb.second;
 
       // Create a `JacobianFactor` from the system [A b] and add it to the
       // `GaussianFactorGraph`.

--- a/include/dcsam/DCMaxMixtureFactor.h
+++ b/include/dcsam/DCMaxMixtureFactor.h
@@ -47,7 +47,7 @@ class DCMaxMixtureFactor : public DCFactor {
                               const bool normalized)
       : Base(continuousKeys, discreteKeys), normalized_(normalized) {
     factors_ = factors;
-    for (int i = 0; i < weights.size(); i++) {
+    for (size_t i = 0; i < weights.size(); i++) {
       log_weights_.push_back(log(weights[i]));
     }
   }
@@ -58,7 +58,7 @@ class DCMaxMixtureFactor : public DCFactor {
                               const bool normalized)
       : Base(continuousKeys, discreteKeys), normalized_(normalized) {
     factors_ = factors;
-    for (int i = 0; i < factors_.size(); i++) {
+    for (size_t i = 0; i < factors_.size(); i++) {
       log_weights_.push_back(0);
     }
   }
@@ -85,7 +85,7 @@ class DCMaxMixtureFactor : public DCFactor {
                             const DiscreteValues& discreteVals) const {
     double min_error = std::numeric_limits<double>::infinity();
     size_t min_error_idx;
-    for (int i = 0; i < factors_.size(); i++) {
+    for (size_t i = 0; i < factors_.size(); i++) {
       double error =
           factors_[i].error(continuousVals, discreteVals) - log_weights_[i];
       if (!normalized_)

--- a/include/dcsam/DCMaxMixtureFactor.h
+++ b/include/dcsam/DCMaxMixtureFactor.h
@@ -1,5 +1,5 @@
 /**
- * @file SemanticMaxMixtureFactor.h
+ * @file DCMaxMixtureFactor.h
  * @brief Discrete-Continuous Max-Mixture factor providing several extra
  * interfaces for weight updates and association retrieval
  * @author Kurran Singh, singhk@mit.edu
@@ -20,7 +20,7 @@
 namespace dcsam {
 
 /**
- * @brief Implementation of a semantic max-mixture factor
+ * @brief Implementation of a discrete-continuous max-mixture factor
  *
  * r(x) = min_i -log(w_i) + r_i(x)
  *

--- a/include/dcsam/DCSAM_types.h
+++ b/include/dcsam/DCSAM_types.h
@@ -6,13 +6,13 @@
  * Copyright 2021 The Ambitious Folks of the MRG
  */
 
+#pragma once
+
 #include <gtsam/discrete/DiscreteFactor.h>
 #include <gtsam/discrete/DiscreteMarginals.h>
 #include <gtsam/nonlinear/Marginals.h>
 
 #include <utility>
-
-#pragma once
 
 namespace dcsam {
 

--- a/include/dcsam/DCSAM_utils.h
+++ b/include/dcsam/DCSAM_utils.h
@@ -1,0 +1,78 @@
+/**
+ *
+ * @file DCSAM_utils.h
+ * @brief Some utilities for DCSAM
+ * @author Kevin Doherty, kdoherty@mit.edu
+ * Copyright 2021 The Ambitious Folks of the MRG
+ */
+
+#pragma once
+
+#include <gtsam/base/Vector.h>
+#include <math.h>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace dcsam {
+
+inline std::vector<double> expNormalize(const std::vector<double> &logProbs) {
+  /*
+   * Normalizing a set of log probabilities in a numerically stable way is
+   * tricky. To avoid overflow/underflow issues, we compute the largest
+   * (finite) log probability and subtract it from each log probability before
+   * normalizing. This comes from the observation that if:
+   *    p_i = exp(L_i) / ( sum_j exp(L_j) ),
+   * Then,
+   *    p_i = exp(Z) exp(L_i - Z) / (exp(Z) sum_j exp(L_j - Z)),
+   *        = exp(L_i - Z) / ( sum_j exp(L_j - Z) )
+   *
+   * Setting Z = max_j L_j, we can avoid numerical issues that arise when all
+   * of the (unnormalized) log probabilities are either very large or very
+   * small.
+   */
+  double maxLogProb = -std::numeric_limits<double>::infinity();
+  for (size_t i = 0; i < logProbs.size(); i++) {
+    double logProb = logProbs[i];
+    if ((logProb != std::numeric_limits<double>::infinity()) &&
+        logProb > maxLogProb) {
+      maxLogProb = logProb;
+    }
+  }
+
+  // After computing the max = "Z" of the log probabilities L_i, we compute
+  // the log of the normalizing constant, log S, where S = sum_j exp(L_j - Z).
+  double total = 0.0;
+  for (size_t i = 0; i < logProbs.size(); i++) {
+    double probPrime = exp(logProbs[i] - maxLogProb);
+    total += probPrime;
+  }
+  double logTotal = log(total);
+
+  // Now we compute the (normalized) probability (for each i):
+  // p_i = exp(L_i - Z - log S)
+  double checkNormalization = 0.0;
+  std::vector<double> probs;
+  for (size_t i = 0; i < logProbs.size(); i++) {
+    double prob = exp(logProbs[i] - maxLogProb - logTotal);
+    probs.push_back(prob);
+    checkNormalization += prob;
+  }
+
+  // Numerical tolerance for floating point comparisons
+  double tol = 1e-9;
+
+  if (!gtsam::fpEqual(checkNormalization, 1.0, tol)) {
+    std::string errMsg =
+        std::string("expNormalize failed to normalize probabilities. ") +
+        std::string("Expected normalization constant = 1.0. Got value: ") +
+        std::to_string(checkNormalization) +
+        std::string(
+            "\n This could have resulted from numerical overflow/underflow.");
+    throw std::logic_error(errMsg);
+  }
+  return probs;
+}
+
+}  // namespace dcsam

--- a/include/dcsam/SemanticBearingRangeFactor.h
+++ b/include/dcsam/SemanticBearingRangeFactor.h
@@ -72,6 +72,7 @@ class SemanticBearingRangeFactor : public DCFactor {
     this->probs_ = rhs.probs_;
     this->keys_ = rhs.keys_;
     this->discreteKeys_ = rhs.discreteKeys_;
+    return *this;
   }
 
   // Error is the sum of the continuous and discrete negative

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 option(ENABLE_PLOTTING "Enable plotting (requires matplotlibcpp)" OFF)
 
 if (ENABLE_PLOTTING)
-find_package(matplotlibcpp REQUIRED)
+  message(STATUS "Plotting enabled. Building tests with plotting.")
+  find_package(matplotlibcpp REQUIRED)
 endif()
 
 # The gtest/gtest_main targets carry header search path

--- a/tests/testDCSAM.cpp
+++ b/tests/testDCSAM.cpp
@@ -29,6 +29,7 @@
 // Our custom DCSAM includes
 #include "dcsam/DCContinuousFactor.h"
 #include "dcsam/DCDiscreteFactor.h"
+#include "dcsam/DCEMFactor.h"
 #include "dcsam/DCMaxMixtureFactor.h"
 #include "dcsam/DCMixtureFactor.h"
 #include "dcsam/DCSAM.h"
@@ -1268,14 +1269,196 @@ TEST(TestSuite, dcMaxMixture_semantic_slam) {
 
     // build mixture: dcmaxmixture should be picking the component for lm1
     SemanticBearingRangeFactor<gtsam::Pose2, gtsam::Point2> sbr1(
-                xi, l1, lm1_class, semantic_meas, bearing1, range1, br_noise);
+        xi, l1, lm1_class, semantic_meas, bearing1, range1, br_noise);
     SemanticBearingRangeFactor<gtsam::Pose2, gtsam::Point2> sbr2(
-                xi, l2, lm2_class, semantic_meas, bearing1, range1, br_noise);
-    DCMaxMixtureFactor<SemanticBearingRangeFactor<gtsam::Pose2,
-                                                  gtsam::Point2>> dcmmf(
-                            {xi, l1, l2}, dks, {sbr1, sbr2}, {.5, .5}, false);
+        xi, l2, lm2_class, semantic_meas, bearing1, range1, br_noise);
+    DCMaxMixtureFactor<SemanticBearingRangeFactor<gtsam::Pose2, gtsam::Point2>>
+        dcmmf({xi, l1, l2}, dks, {sbr1, sbr2}, {.5, .5}, false);
 
     hfg.push_dc(dcmmf);
+    odom = odom * meas;
+    initialGuess.insert(xj, odom);
+    dcsam.update(hfg, initialGuess);
+    DCValues dcvals = dcsam.calculateEstimate();
+
+    size_t mpeClassL1 = dcvals.discrete.at(lc1);
+
+    // Plot poses and landmarks
+#ifdef ENABLE_PLOTTING
+    std::vector<double> xs, ys;
+    for (size_t j = 0; j < i + 2; j++) {
+      xs.push_back(
+          dcvals.continuous.at<gtsam::Pose2>(gtsam::Symbol('x', j)).x());
+      ys.push_back(
+          dcvals.continuous.at<gtsam::Pose2>(gtsam::Symbol('x', j)).y());
+    }
+
+    std::vector<double> lmxs, lmys;
+    lmxs.push_back(
+        dcvals.continuous.at<gtsam::Point2>(gtsam::Symbol('l', 1)).x());
+    lmys.push_back(
+        dcvals.continuous.at<gtsam::Point2>(gtsam::Symbol('l', 1)).y());
+
+    string color = (mpeClassL1 == 0) ? "b" : "orange";
+
+    plt::plot(xs, ys);
+    plt::scatter(lmxs, lmys, {{"color", color}});
+    plt::show();
+#endif
+
+    hfg.clear();
+    initialGuess.clear();
+  }
+
+  gtsam::Symbol x7('x', 7);
+  gtsam::BetweenFactor<gtsam::Pose2> bw(x0, x7, dx * noise, meas_noise);
+
+  hfg.push_nonlinear(bw);
+  dcsam.update(hfg, initialGuess);
+
+  DCValues dcvals = dcsam.calculateEstimate();
+
+  size_t mpeClassL1 = dcvals.discrete.at(lc1);
+
+  // Plot the poses and landmarks
+#ifdef ENABLE_PLOTTING
+  std::vector<double> xs, ys;
+  for (size_t i = 0; i < 8; i++) {
+    xs.push_back(dcvals.continuous.at<gtsam::Pose2>(gtsam::Symbol('x', i)).x());
+    ys.push_back(dcvals.continuous.at<gtsam::Pose2>(gtsam::Symbol('x', i)).y());
+  }
+
+  std::vector<double> lmxs, lmys;
+  lmxs.push_back(
+      dcvals.continuous.at<gtsam::Point2>(gtsam::Symbol('l', 1)).x());
+  lmys.push_back(
+      dcvals.continuous.at<gtsam::Point2>(gtsam::Symbol('l', 1)).y());
+
+  string color = (mpeClassL1 == 0) ? "b" : "orange";
+
+  plt::plot(xs, ys);
+  plt::scatter(lmxs, lmys, {{"color", color}});
+  plt::show();
+#endif
+
+  EXPECT_EQ(mpeClassL1, 1);
+}
+
+TEST(TestSuite, simple_dcemfactor) {
+  // Make a factor graph
+  HybridFactorGraph hfg;
+
+  // Values for initial guess
+  gtsam::Values initialGuess;
+  DiscreteValues initialGuessDiscrete;
+
+  gtsam::Symbol x0('x', 0);
+  gtsam::Symbol l1('l', 1);
+  gtsam::Symbol lc1('c', 1);
+  // Create a discrete key for landmark 1 class with cardinality 2.
+  gtsam::DiscreteKey lm1_class(lc1, 2);
+  gtsam::Pose2 pose0(0, 0, 0);
+  gtsam::Pose2 dx(1, 0, 0.78539816);
+  double prior_sigma = 0.1;
+  double meas_sigma = 1.0;
+  double circumradius = (std::sqrt(4 + 2 * std::sqrt(2))) / 2.0;
+  gtsam::Point2 landmark1(circumradius, circumradius);
+
+  gtsam::noiseModel::Isotropic::shared_ptr prior_noise =
+      gtsam::noiseModel::Isotropic::Sigma(3, prior_sigma);
+  gtsam::noiseModel::Isotropic::shared_ptr prior_lm_noise =
+      gtsam::noiseModel::Isotropic::Sigma(2, prior_sigma);
+  gtsam::noiseModel::Isotropic::shared_ptr meas_noise =
+      gtsam::noiseModel::Isotropic::Sigma(3, meas_sigma);
+
+  // 0.1 rad std on bearing, 10cm on range
+  gtsam::noiseModel::Isotropic::shared_ptr br_noise =
+      gtsam::noiseModel::Isotropic::Sigma(2, 0.1);
+
+  std::vector<double> prior_lm1_class;
+  prior_lm1_class.push_back(0.9);
+  prior_lm1_class.push_back(0.1);
+
+  gtsam::PriorFactor<gtsam::Pose2> p0(x0, pose0, prior_noise);
+  gtsam::PriorFactor<gtsam::Point2> pl1(l1, landmark1, prior_lm_noise);
+  DiscretePriorFactor plc1(lm1_class, prior_lm1_class);
+
+  initialGuess.insert(x0, pose0);
+  initialGuess.insert(l1, landmark1);
+  initialGuessDiscrete[lm1_class.first] = 0;
+
+  hfg.push_nonlinear(p0);
+  hfg.push_nonlinear(pl1);
+  hfg.push_discrete(plc1);
+
+  // set up for landmark 2
+  gtsam::Symbol l2('l', 2);
+  gtsam::Symbol lc2('c', 2);
+  // Create a discrete key for landmark 2 class with cardinality 2.
+  gtsam::DiscreteKey lm2_class(lc2, 2);
+  gtsam::Point2 landmark2(circumradius + .5, circumradius + 5);
+
+  std::vector<double> prior_lm2_class;
+  prior_lm2_class.push_back(0.1);
+  prior_lm2_class.push_back(0.9);
+
+  gtsam::PriorFactor<gtsam::Point2> pl2(l2, landmark2, prior_lm_noise);
+  DiscretePriorFactor plc2(lm2_class, prior_lm2_class);
+
+  initialGuess.insert(l2, landmark2);
+  initialGuessDiscrete[lm2_class.first] = 1;
+
+  hfg.push_nonlinear(pl2);
+  hfg.push_discrete(plc2);
+
+  // Setup dcsam
+  DCSAM dcsam;
+  dcsam.update(hfg, initialGuess, initialGuessDiscrete);
+
+  DCValues dcval_start = dcsam.calculateEstimate();
+  std::cout << "Printing first values" << std::endl;
+  dcval_start.discrete.print();
+
+  hfg.clear();
+  initialGuess.clear();
+  initialGuessDiscrete.clear();
+
+  gtsam::Pose2 odom(pose0);
+  gtsam::Pose2 noise(0.01, 0.01, 0.01);
+  for (size_t i = 0; i < 7; i++) {
+    gtsam::Symbol xi('x', i);
+    gtsam::Symbol xj('x', i + 1);
+
+    gtsam::Pose2 meas = dx * noise;
+
+    gtsam::BetweenFactor<gtsam::Pose2> bw(xi, xj, meas, meas_noise);
+    hfg.push_nonlinear(bw);
+
+    // Add semantic bearing-range measurement to landmark in center
+    gtsam::Rot2 bearing1 = gtsam::Rot2::fromDegrees(67.5);
+    double range1 = circumradius;
+
+    // For the first couple measurements, pick class=0, later pick class=1
+    std::vector<double> semantic_meas;
+    if (i < 2) {
+      semantic_meas.push_back(0.9);
+      semantic_meas.push_back(0.1);
+    } else {
+      semantic_meas.push_back(0.1);
+      semantic_meas.push_back(0.9);
+    }
+
+    gtsam::DiscreteKeys dks({lm1_class, lm2_class});
+
+    // build mixture: dcemfactor should be picking the component for lm1
+    SemanticBearingRangeFactor<gtsam::Pose2, gtsam::Point2> sbr1(
+        xi, l1, lm1_class, semantic_meas, bearing1, range1, br_noise);
+    SemanticBearingRangeFactor<gtsam::Pose2, gtsam::Point2> sbr2(
+        xi, l2, lm2_class, semantic_meas, bearing1, range1, br_noise);
+    DCEMFactor<SemanticBearingRangeFactor<gtsam::Pose2, gtsam::Point2>> dcemf(
+        {xi, l1, l2}, dks, {sbr1, sbr2}, {.5, .5}, false);
+
+    hfg.push_dc(dcemf);
     odom = odom * meas;
     initialGuess.insert(xj, odom);
     dcsam.update(hfg, initialGuess);


### PR DESCRIPTION
This PR adds discrete-continuous expectation-maximization factors (see `DCEMFactor.h`).

Still technically a WIP - needs a little bit of refactoring and cleanup, but basic functionality is there.

There are also a few other minor changes, including
- Addressing `int` to `size_t` conversion in some loops
- Moving exp normalization code to `DCSAM_utils.h`