### PR TITLE
Allow specification of variable ordering in discrete marginal computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DCSAM_HDRS
   include/dcsam/SmartSemanticBearingRangeFactor.h
   include/dcsam/DCMaxMixtureFactor.h
   include/dcsam/DCEMFactor.h
+  include/dcsam/DiscreteMarginalsOrdered.h
   )
 
 set(DCSAM_SRCS

--- a/include/dcsam/DiscreteMarginalsOrdered.h
+++ b/include/dcsam/DiscreteMarginalsOrdered.h
@@ -25,7 +25,7 @@ class DiscreteMarginalsOrdered : public gtsam::DiscreteMarginals {
   using Base = gtsam::DiscreteMarginals;
   DiscreteMarginalsOrdered(const gtsam::DiscreteFactorGraph &graph,
                            const gtsam::Ordering::OrderingType &orderingType =
-                               gtsam::Ordering::OrderingType::COLAMD)
+                               gtsam::Ordering::OrderingType::NATURAL)
       : Base(gtsam::DiscreteFactorGraph()) {
     gtsam::Ordering ordering;
     if (orderingType == gtsam::Ordering::OrderingType::COLAMD) {

--- a/include/dcsam/DiscreteMarginalsOrdered.h
+++ b/include/dcsam/DiscreteMarginalsOrdered.h
@@ -11,6 +11,8 @@
 #include <gtsam/discrete/DiscreteFactorGraph.h>
 #include <gtsam/discrete/DiscreteMarginals.h>
 
+#include <utility>
+
 #include "DCSAM_types.h"
 
 namespace dcsam {
@@ -23,7 +25,7 @@ class DiscreteMarginalsOrdered : public gtsam::DiscreteMarginals {
   using Base = gtsam::DiscreteMarginals;
   DiscreteMarginalsOrdered(const gtsam::DiscreteFactorGraph &graph,
                            const gtsam::Ordering::OrderingType &orderingType =
-                               gtsam::Ordering::OrderingType::NATURAL)
+                               gtsam::Ordering::OrderingType::COLAMD)
       : Base(gtsam::DiscreteFactorGraph()) {
     gtsam::Ordering ordering;
     if (orderingType == gtsam::Ordering::OrderingType::COLAMD) {
@@ -33,7 +35,39 @@ class DiscreteMarginalsOrdered : public gtsam::DiscreteMarginals {
     } else {
       ordering = gtsam::Ordering::Natural(graph);
     }
-    bayesTree_ = graph.eliminateMultifrontal(ordering);
+    bayesTree_ = graph.eliminateMultifrontal(ordering, CustomEliminateDiscrete);
+  }
+
+  static std::pair<gtsam::DiscreteConditional::shared_ptr,
+                   gtsam::DecisionTreeFactor::shared_ptr>
+  CustomEliminateDiscrete(const gtsam::DiscreteFactorGraph &factors,
+                          const gtsam::Ordering &frontalKeys) {
+    // PRODUCT: multiply all factors.
+    gtsam::DecisionTreeFactor product;
+    for (auto &factor : factors) {
+      if (!factor) {
+        std::cout << "Null factor in eliminate" << std::endl;
+      } else {
+        // Unsure why factors is getting a nullptr. Try simply ignoring:
+        product = (*factor) * product;
+      }
+    }
+
+    // sum out frontals to get the factor on the separator.
+    gtsam::DecisionTreeFactor::shared_ptr sum = product.sum(frontalKeys);
+
+    // NOTE: Sum keys seems to be empty often - is this normal?
+    // Ordering keys for the conditional so that frontalKeys is in front.
+    gtsam::Ordering orderedKeys;
+    orderedKeys.insert(orderedKeys.end(), frontalKeys.begin(),
+                       frontalKeys.end());
+    orderedKeys.insert(orderedKeys.end(), sum->keys().begin(),
+                       sum->keys().end());
+
+    gtsam::DiscreteConditional::shared_ptr cond(
+        new gtsam::DiscreteConditional(product, *sum, orderedKeys));
+
+    return std::make_pair(cond, sum);
   }
 };
 

--- a/include/dcsam/DiscreteMarginalsOrdered.h
+++ b/include/dcsam/DiscreteMarginalsOrdered.h
@@ -1,0 +1,40 @@
+/**
+ *
+ * @file DiscreteMarginalsOrdererd.h
+ * @brief Custom discrete marginals
+ * @author Kevin Doherty, kdoherty@mit.edu
+ * Copyright 2021 The Ambitious Folks of the MRG
+ */
+
+#pragma once
+
+#include <gtsam/discrete/DiscreteFactorGraph.h>
+#include <gtsam/discrete/DiscreteMarginals.h>
+
+#include "DCSAM_types.h"
+
+namespace dcsam {
+
+/**
+ * @brief Simple discrete marginals class allowing specific ordering
+ */
+class DiscreteMarginalsOrdered : public gtsam::DiscreteMarginals {
+ public:
+  using Base = gtsam::DiscreteMarginals;
+  DiscreteMarginalsOrdered(const gtsam::DiscreteFactorGraph &graph,
+                           const gtsam::Ordering::OrderingType &orderingType =
+                               gtsam::Ordering::OrderingType::COLAMD)
+      : Base(gtsam::DiscreteFactorGraph()) {
+    gtsam::Ordering ordering;
+    if (orderingType == gtsam::Ordering::OrderingType::COLAMD) {
+      ordering = gtsam::Ordering::Colamd(graph);
+    } else if (orderingType == gtsam::Ordering::OrderingType::METIS) {
+      ordering = gtsam::Ordering::Metis(graph);
+    } else {
+      ordering = gtsam::Ordering::Natural(graph);
+    }
+    bayesTree_ = graph.eliminateMultifrontal(ordering);
+  }
+};
+
+}  // namespace dcsam

--- a/include/dcsam/DiscreteMarginalsOrdered.h
+++ b/include/dcsam/DiscreteMarginalsOrdered.h
@@ -23,7 +23,7 @@ class DiscreteMarginalsOrdered : public gtsam::DiscreteMarginals {
   using Base = gtsam::DiscreteMarginals;
   DiscreteMarginalsOrdered(const gtsam::DiscreteFactorGraph &graph,
                            const gtsam::Ordering::OrderingType &orderingType =
-                               gtsam::Ordering::OrderingType::COLAMD)
+                               gtsam::Ordering::OrderingType::NATURAL)
       : Base(gtsam::DiscreteFactorGraph()) {
     gtsam::Ordering ordering;
     if (orderingType == gtsam::Ordering::OrderingType::COLAMD) {

--- a/src/DCSAM.cpp
+++ b/src/DCSAM.cpp
@@ -10,6 +10,7 @@
 
 #include "dcsam/DCContinuousFactor.h"
 #include "dcsam/DCDiscreteFactor.h"
+#include "dcsam/DiscreteMarginalsOrdered.h"
 
 namespace dcsam {
 
@@ -63,7 +64,8 @@ void DCSAM::update(const gtsam::NonlinearFactorGraph &graph,
   // component
   for (auto &dcfactor : dcfg) {
     DCDiscreteFactor dcDiscreteFactor(dcfactor);
-    auto sharedDiscrete = boost::make_shared<DCDiscreteFactor>(dcDiscreteFactor);
+    auto sharedDiscrete =
+        boost::make_shared<DCDiscreteFactor>(dcDiscreteFactor);
     discreteCombined.push_back(sharedDiscrete);
     dcDiscreteFactors_.push_back(sharedDiscrete);
   }
@@ -76,7 +78,8 @@ void DCSAM::update(const gtsam::NonlinearFactorGraph &graph,
 
   for (auto &dcfactor : dcfg) {
     DCContinuousFactor dcContinuousFactor(dcfactor);
-    auto sharedContinuous = boost::make_shared<DCContinuousFactor>(dcContinuousFactor);
+    auto sharedContinuous =
+        boost::make_shared<DCContinuousFactor>(dcContinuousFactor);
     sharedContinuous->updateDiscrete(currDiscrete_);
     combined.push_back(sharedContinuous);
     dcContinuousFactors_.push_back(sharedContinuous);
@@ -118,8 +121,8 @@ void DCSAM::updateDiscreteInfo(const gtsam::Values &continuousVals,
   for (auto factor : dcDiscreteFactors_) {
     boost::shared_ptr<DCDiscreteFactor> dcDiscrete =
         boost::static_pointer_cast<DCDiscreteFactor>(factor);
-      dcDiscrete->updateContinuous(continuousVals);
-      dcDiscrete->updateDiscrete(discreteVals);
+    dcDiscrete->updateContinuous(continuousVals);
+    dcDiscrete->updateDiscrete(discreteVals);
   }
 }
 
@@ -135,11 +138,10 @@ void DCSAM::updateContinuousInfo(const DiscreteValues &discreteVals,
   gtsam::FastMap<gtsam::FactorIndex, gtsam::KeySet> newAffectedKeys;
   for (size_t j = 0; j < dcContinuousFactors_.size(); j++) {
     boost::shared_ptr<DCContinuousFactor> dcContinuousFactor =
-      boost::static_pointer_cast<DCContinuousFactor>(dcContinuousFactors_[j]);
+        boost::static_pointer_cast<DCContinuousFactor>(dcContinuousFactors_[j]);
     dcContinuousFactor->updateDiscrete(discreteVals);
     for (const gtsam::Key &k : dcContinuousFactor->keys()) {
       newAffectedKeys[j].insert(k);
-
     }
   }
   updateParams.newAffectedKeys = std::move(newAffectedKeys);
@@ -165,7 +167,7 @@ DCMarginals DCSAM::getMarginals(const gtsam::NonlinearFactorGraph &graph,
                                 const gtsam::Values &continuousEst,
                                 const gtsam::DiscreteFactorGraph &dfg) {
   return DCMarginals{.continuous = gtsam::Marginals(graph, continuousEst),
-                     .discrete = gtsam::DiscreteMarginals(dfg)};
+                     .discrete = dcsam::DiscreteMarginalsOrdered(dfg)};
 }
 
 }  // namespace dcsam


### PR DESCRIPTION
Straightforward wrapper around `gtsam::DiscreteMarginals` allowing for different variable ordering choices, or even custom orderings.

Branches off of `feature/emfactors` so we should merge that into `main` first.