### PR TITLE
Fix max-mixture weights and cache solves

### DIFF
--- a/src/DCSAM.cpp
+++ b/src/DCSAM.cpp
@@ -74,7 +74,12 @@ void DCSAM::update(const gtsam::NonlinearFactorGraph &graph,
   updateDiscrete(discreteCombined, currContinuous_, currDiscrete_);
 
   // Update current discrete state estimate.
-  currDiscrete_ = solveDiscrete();
+  if (!initialGuessContinuous.empty() && initialGuessDiscrete.empty() &&
+      discreteCombined.empty()) {
+    // This is an odometry?
+  } else {
+    currDiscrete_ = solveDiscrete();
+  }
 
   for (auto &dcfactor : dcfg) {
     DCContinuousFactor dcContinuousFactor(dcfactor);
@@ -156,9 +161,10 @@ DiscreteValues DCSAM::solveDiscrete() const {
 DCValues DCSAM::calculateEstimate() const {
   // NOTE: if we have these cached from solves, we could presumably just return
   // the cached values.
-  gtsam::Values continuousVals = isam_.calculateEstimate();
-  DiscreteValues discreteVals = (*dfg_.optimize());
-  DCValues dcValues(continuousVals, discreteVals);
+  // gtsam::Values continuousVals = isam_.calculateEstimate();
+  // DiscreteValues discreteVals = (*dfg_.optimize());
+  // DCValues dcValues(continuousVals, discreteVals);
+  DCValues dcValues(currContinuous_, currDiscrete_);
   return dcValues;
 }
 


### PR DESCRIPTION
This PR fixes an issue with max-mixture weights (not being included in error computations properly) and caches solves.

We added a heuristic to determine whether re-solves are needed for discrete variables. Essentially we try to determine when the added factor graph consists only of odometry measurements and don't bother updating in this case. This is a bit of a hack as, in principle, new continuous factors could come in that influence the DC states and shift discrete hypotheses, but this isn't so in our experiments. Consequently, this isn't strictly correct in the general case, so I'm really not sure it should be in the main instantiation of this solver. I think I might instead revert this commit and add affordances to the front-end so a user can determine whether a fresh discrete solve is needed. What do you think @520xyxyzq ?