### PR TITLE
Revert caching of solutions in calculateEstimate.

### DIFF
--- a/src/DCSAM.cpp
+++ b/src/DCSAM.cpp
@@ -161,10 +161,9 @@ DiscreteValues DCSAM::solveDiscrete() const {
 DCValues DCSAM::calculateEstimate() const {
   // NOTE: if we have these cached from solves, we could presumably just return
   // the cached values.
-  // gtsam::Values continuousVals = isam_.calculateEstimate();
-  // DiscreteValues discreteVals = (*dfg_.optimize());
-  // DCValues dcValues(continuousVals, discreteVals);
-  DCValues dcValues(currContinuous_, currDiscrete_);
+  gtsam::Values continuousVals = isam_.calculateEstimate();
+  DiscreteValues discreteVals = (*dfg_.optimize());
+  DCValues dcValues(continuousVals, discreteVals);
   return dcValues;
 }
 


### PR DESCRIPTION
Reverts caching of solutions in `DCSAM::calculateEstimate` resulting in a slower implementation but better estimates.