### PR TITLE
Some minor fixes and additions for smarter updates.

### DIFF
--- a/include/dcsam/DCContinuousFactor.h
+++ b/include/dcsam/DCContinuousFactor.h
@@ -74,12 +74,18 @@ class DCContinuousFactor : public gtsam::NonlinearFactor {
 
   ~DCContinuousFactor() = default;
 
-  void updateDiscrete(const DiscreteValues& discreteVals) {
+  bool updateDiscrete(const DiscreteValues& discreteVals) {
+    bool updated = false;
     for (const gtsam::DiscreteKey& dk : discreteKeys_) {
       const gtsam::Key k = dk.first;
-      if (discreteVals.find(k) != discreteVals.end())
-        discreteVals_[k] = discreteVals.at(k);
+      if (discreteVals.find(k) != discreteVals.end()) {
+        if (discreteVals.at(k) != discreteVals_[k]) {
+          discreteVals_[k] = discreteVals.at(k);
+          updated = true;
+        }
+      }
     }
+    return updated;
   }
 
   size_t dim() const override { return dcfactor_->dim(); }

--- a/include/dcsam/DCMaxMixtureFactor.h
+++ b/include/dcsam/DCMaxMixtureFactor.h
@@ -74,6 +74,8 @@ class DCMaxMixtureFactor : public DCFactor {
   double error(const gtsam::Values& continuousVals,
                const DiscreteValues& discreteVals) const override {
     size_t min_error_idx = getActiveFactorIdx(continuousVals, discreteVals);
+    assert(0 <= min_error_idx);
+    assert(min_error_idx < factors_.size());
     double min_error =
         factors_[min_error_idx].error(continuousVals, discreteVals);
     if (normalized_) return min_error - log_weights_[min_error_idx];
@@ -85,7 +87,7 @@ class DCMaxMixtureFactor : public DCFactor {
   size_t getActiveFactorIdx(const gtsam::Values& continuousVals,
                             const DiscreteValues& discreteVals) const {
     double min_error = std::numeric_limits<double>::infinity();
-    size_t min_error_idx;
+    size_t min_error_idx = 0;
     for (size_t i = 0; i < factors_.size(); i++) {
       double error =
           factors_[i].error(continuousVals, discreteVals) - log_weights_[i];


### PR DESCRIPTION
The original version of DC-SAM updated every continuous variable influenced by a discrete variable independent of whether the discrete variable changed. This PR makes the update functions for DCContinuousFactors return a `bool` indicating whether the cached discrete variables have been modified. If this flag is false, we need not mark the corresponding continuous keys as "affected" for subsequent iSAM calls.