### PR TITLE
Update to GTSAM 4.2a8 and clean up

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
         args: ['--maxkb=3000']
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.8.2
     hooks:
     -   id: flake8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,58 +1,36 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(dcsam)
 
 # Set some compilation options.
 set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-Wall -Wpedantic -Wextra)
+if (NOT CMAKE_BUILD_TYPE)
+  # Options: Debug, Release, MinSizeRel, RelWithDebInfo
+  message(STATUS "No build type selected, default to Release")
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
 
 # Add option to enable testing
-option(ENABLE_TESTS "Enable tests" OFF)
+option(DCSAM_ENABLE_TESTS "Enable tests" OFF)
 
 # External package dependencies.
-find_package(GTSAM 4.1 REQUIRED)
+find_package(GTSAM 4.2 REQUIRED)
 find_package(Eigen3 3.3 REQUIRED)
 
 # add_definitions(-march=native)
 # add_definitions(-std=c++1z)
 
-set(DCSAM_HDRS
-  include/dcsam/DCSAM_types.h
-  include/dcsam/DCSAM_utils.h
-  include/dcsam/DCSAM.h
-  include/dcsam/DCFactor.h
-  include/dcsam/DCContinuousFactor.h
-  include/dcsam/DCDiscreteFactor.h
-  include/dcsam/DCMixtureFactor.h
-  include/dcsam/DiscretePriorFactor.h
-  include/dcsam/SmartDiscretePriorFactor.h
-  include/dcsam/HybridFactorGraph.h
-  include/dcsam/SemanticBearingRangeFactor.h
-  include/dcsam/SmartSemanticBearingRangeFactor.h
-  include/dcsam/DCMaxMixtureFactor.h
-  include/dcsam/DCEMFactor.h
-  include/dcsam/DiscreteMarginalsOrdered.h
-  )
-
-set(DCSAM_SRCS
-  src/DCSAM.cpp
-  src/HybridFactorGraph.cpp
-  )
-
-set(DCSAM_LIBS
-  gtsam
-  Eigen3::Eigen
-  )
-
-add_library(dcsam STATIC ${DCSAM_SRCS} ${DCSAM_HDRS})
+add_library(dcsam SHARED)
+target_sources(dcsam PRIVATE src/DCSAM.cpp src/HybridFactorGraph.cpp)
 target_include_directories(dcsam PUBLIC include)
-target_link_libraries(dcsam PUBLIC ${DCSAM_LIBS})
+target_link_libraries(dcsam PUBLIC Eigen3::Eigen gtsam)
+target_compile_options(dcsam PRIVATE -Wall -Wpedantic -Wextra)
 
 # Make library accessible to other cmake projects
 export(PACKAGE dcsam)
 export(TARGETS dcsam FILE dcsamConfig.cmake)
 
 # Include unit tests directory to the project.
-if (${ENABLE_TESTS})
+if(DCSAM_ENABLE_TESTS)
   message(STATUS "Testing enabled. Building tests.")
   enable_testing()
   add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ A technical report describing this library and our solver can be found [here](ht
 
 To retrieve the appropriate version of GTSAM:
 ```sh
-~/$ git clone https://github.com/borglab/gtsam
-~/$ cd gtsam
-~/gtsam/$ git checkout 4.2a8
+~ $ git clone https://github.com/borglab/gtsam
+~ $ cd gtsam
+~/gtsam $ git checkout 4.2a8
 ```
 Follow instructions in the GTSAM repository to build and install with your desired configuration.
 
@@ -44,26 +44,26 @@ Follow instructions in the GTSAM repository to build and install with your desir
 To build using `cmake`:
 
 ```bash
-~/dcsam/$ mkdir build
-~/dcsam/$ cd build
-~/dcsam/build$ cmake ..
-~/dcsam/build$ make -j
+~/dcsam $ mkdir build
+~/dcsam $ cd build
+~/dcsam/build $ cmake ..
+~/dcsam/build $ make -j
 ```
 
 ### Run tests
 
 To run unit tests, first build with testing enabled:
 ```bash
-~/$ mkdir build
-~/$ cd build
-~/build$ cmake .. -DENABLE_TESTS=ON
-~/build$ make -j
+~/dcsam $ mkdir build
+~/dcsam $ cd build
+~/dcsam/build $ cmake .. -DENABLE_TESTS=ON
+~/dcsam/build $ make -j
 ```
 
 Now you can run the tests as follows:
 
 ```bash
-~/build$ make test
+~/dcsam/build $ make test
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run unit tests, first build with testing enabled:
 ```bash
 ~/dcsam $ mkdir build
 ~/dcsam $ cd build
-~/dcsam/build $ cmake .. -DENABLE_TESTS=ON
+~/dcsam/build $ cmake .. -DDCSAM_ENABLE_TESTS=ON
 ~/dcsam/build $ make -j
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A technical report describing this library and our solver can be found [here](ht
 ```bibtex
 @article{doherty2022discrete,
   author={Doherty, Kevin J. and Lu, Ziqi and Singh, Kurran and Leonard, John J.},
-  journal={IEEE Robotics and Automation Letters}, 
-  title={Discrete-{C}ontinuous {S}moothing and {M}apping}, 
+  journal={IEEE Robotics and Automation Letters},
+  title={Discrete-{C}ontinuous {S}moothing and {M}apping},
   year={2022},
   volume={7},
   number={4},
@@ -22,13 +22,13 @@ A technical report describing this library and our solver can be found [here](ht
 
 ## Prerequisites
 
-- [GTSAM](https://github.com/borglab/gtsam) @ `caa14bc`
+- [GTSAM](https://github.com/borglab/gtsam) @ `4.2a8`
 
 To retrieve the appropriate version of GTSAM:
 ```sh
 ~/$ git clone https://github.com/borglab/gtsam
 ~/$ cd gtsam
-~/gtsam/$ git checkout caa14bc
+~/gtsam/$ git checkout 4.2a8
 ```
 Follow instructions in the GTSAM repository to build and install with your desired configuration.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,13 @@
-option(ENABLE_PLOTTING "Enable plotting (requires matplotlibcpp)" OFF)
-
-if (ENABLE_PLOTTING)
-  message(STATUS "Plotting enabled. Building tests with plotting.")
-  find_package(matplotlibcpp REQUIRED)
-endif()
+option(DCSAM_ENABLE_PLOTTING "Enable plotting (requires matplotlib_cpp)" OFF)
 
 # The gtest/gtest_main targets carry header search path
 # dependencies automatically when using CMake 2.8.11 or
 # later. Otherwise we have to add them here ourselves.
-if (CMAKE_VERSION VERSION_LESS 2.8.11)
+if(CMAKE_VERSION VERSION_LESS 2.8.11)
   include_directories("${gtest_SOURCE_DIR}/include")
 endif()
 
-if (ENABLE_PLOTTING)
-  add_definitions(-DENABLE_PLOTTING=1)
-endif()
-
-# Include tests here...
-add_executable(testDCSAM testDCSAM.cpp)
-
-if (APPLE)
+if(APPLE)
   set(GTEST_LIBS
     /usr/local/lib/libgtest.a
     /usr/local/lib/libgtest_main.a
@@ -28,16 +16,26 @@ else()
   set(GTEST_LIBS
     gtest
     gtest_main
-)
+  )
 endif()
 
+add_executable(testDCSAM testDCSAM.cpp)
+target_link_libraries(testDCSAM dcsam gtsam ${GTEST_LIBS})
 
+# If plotting is enabled, we need to link to matplotlib_cpp
+if(DCSAM_ENABLE_PLOTTING)
+  message(STATUS "Plotting enabled. Building tests with plotting.")
+  include(FetchContent)
+  FetchContent_Declare(matplotlib_cpp
+    GIT_REPOSITORY https://github.com/lava/matplotlib-cpp.git
+    GIT_TAG ef0383f1315d32e0156335e10b82e90b334f6d9f
+  )
+  FetchContent_MakeAvailable(matplotlib_cpp)
 
-# If plotting is enabled, we need to link to matplotlibcpp
-if (ENABLE_PLOTTING)
-  target_link_libraries(testDCSAM dcsam matplotlibcpp gtsam ${GTEST_LIBS})
-else()
-  target_link_libraries(testDCSAM dcsam gtsam ${GTEST_LIBS})
+  target_compile_definitions(testDCSAM PRIVATE ENABLE_PLOTTING=1)
+  target_link_libraries(testDCSAM matplotlib_cpp)
+  # workaround until: https://github.com/lava/matplotlib-cpp/pull/335
+  target_include_directories(testDCSAM PRIVATE ${matplotlib_cpp_SOURCE_DIR})
 endif()
 
 add_test(TestDCSAM testDCSAM)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,16 +26,31 @@ target_link_libraries(testDCSAM dcsam gtsam ${GTEST_LIBS})
 if(DCSAM_ENABLE_PLOTTING)
   message(STATUS "Plotting enabled. Building tests with plotting.")
   include(FetchContent)
-  FetchContent_Declare(matplotlib_cpp
+  FetchContent_Declare(matplotlibcpp
     GIT_REPOSITORY https://github.com/lava/matplotlib-cpp.git
     GIT_TAG ef0383f1315d32e0156335e10b82e90b334f6d9f
   )
-  FetchContent_MakeAvailable(matplotlib_cpp)
+
+  FetchContent_GetProperties(matplotlibcpp)
+  if(NOT matplotlibcpp_POPULATED)
+    FetchContent_Populate(matplotlibcpp)
+
+    find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python3 COMPONENTS NumPy)
+
+    add_library(matplotlibcpp INTERFACE)
+    target_include_directories(matplotlibcpp INTERFACE ${matplotlibcpp_SOURCE_DIR})
+    target_compile_features(matplotlibcpp INTERFACE cxx_std_11)
+    target_link_libraries(matplotlibcpp INTERFACE Python3::Python Python3::Module)
+    if(Python3_NumPy_FOUND)
+      target_link_libraries(matplotlibcpp INTERFACE Python3::NumPy)
+    else()
+      target_compile_definitions(matplotlibcpp INTERFACE WITHOUT_NUMPY)
+    endif()
+  endif()
 
   target_compile_definitions(testDCSAM PRIVATE ENABLE_PLOTTING=1)
-  target_link_libraries(testDCSAM matplotlib_cpp)
-  # workaround until: https://github.com/lava/matplotlib-cpp/pull/335
-  target_include_directories(testDCSAM PRIVATE ${matplotlib_cpp_SOURCE_DIR})
+  target_link_libraries(testDCSAM matplotlibcpp)
 endif()
 
 add_test(TestDCSAM testDCSAM)

--- a/tests/testDCSAM.cpp
+++ b/tests/testDCSAM.cpp
@@ -341,8 +341,8 @@ TEST(TestSuite, dccontinuous_mixture) {
   std::vector<double> initError1{dcMixture.error(initialGuess, dv1)};
   std::vector<double> initErrorNH{dcMixture.error(initialGuess, dvNH)};
 
-  plt::scatter(initVec, initError1, {{"color", "r"}});
-  plt::scatter(initVec, initErrorNH, {{"color", "r"}});
+  plt::scatter(initVec, initError1, 1, {{"color", "r"}});
+  plt::scatter(initVec, initErrorNH, 1, {{"color", "r"}});
 #endif
 
   // We also need an initial guess for the discrete variables (this will only be
@@ -410,8 +410,8 @@ TEST(TestSuite, dccontinuous_mixture) {
   std::vector<double> updatedError1{dcMixture.error(values, dv1)};
   std::vector<double> updatedErrorNH{dcMixture.error(values, dvNH)};
 
-  plt::scatter(updatedVec, updatedError1, {{"color", "b"}});
-  plt::scatter(updatedVec, updatedErrorNH, {{"color", "b"}});
+  plt::scatter(updatedVec, updatedError1, 1, {{"color", "b"}});
+  plt::scatter(updatedVec, updatedErrorNH, 1, {{"color", "b"}});
   plt::show();
 #endif
 
@@ -507,8 +507,8 @@ TEST(TestSuite, simple_mixture_factor) {
   std::vector<double> initError1{dcMixture.error(initialGuess, dv1)};
   std::vector<double> initErrorNH{dcMixture.error(initialGuess, dvNH)};
 
-  plt::scatter(initVec, initError1, {{"color", "r"}});
-  plt::scatter(initVec, initErrorNH, {{"color", "r"}});
+  plt::scatter(initVec, initError1, 1, {{"color", "r"}});
+  plt::scatter(initVec, initErrorNH, 1, {{"color", "r"}});
 #endif
 
   // We also need an initial guess for the discrete variables (this will only be
@@ -537,8 +537,8 @@ TEST(TestSuite, simple_mixture_factor) {
   std::vector<double> updatedError1{dcMixture.error(dcvals.continuous, dv1)};
   std::vector<double> updatedErrorNH{dcMixture.error(dcvals.continuous, dvNH)};
 
-  plt::scatter(updatedVec, updatedError1, {{"color", "b"}});
-  plt::scatter(updatedVec, updatedErrorNH, {{"color", "b"}});
+  plt::scatter(updatedVec, updatedError1, 1, {{"color", "b"}});
+  plt::scatter(updatedVec, updatedErrorNH, 1, {{"color", "b"}});
   plt::show();
 #endif
 
@@ -850,7 +850,7 @@ TEST(TestSuite, simple_semantic_slam) {
     string color = (mpeClassL1 == 0) ? "b" : "orange";
 
     plt::plot(xs, ys);
-    plt::scatter(lmxs, lmys, {{"color", color}});
+    plt::scatter(lmxs, lmys, 1, {{"color", color}});
     plt::show();
 #endif
 
@@ -885,7 +885,7 @@ TEST(TestSuite, simple_semantic_slam) {
   string color = (mpeClassL1 == 0) ? "b" : "orange";
 
   plt::plot(xs, ys);
-  plt::scatter(lmxs, lmys, {{"color", color}});
+  plt::scatter(lmxs, lmys, 1, {{"color", color}});
   plt::show();
 #endif
 
@@ -1114,7 +1114,7 @@ TEST(TestSuite, bearing_range_semantic_slam) {
     string color = (mpeClassL1 == 0) ? "b" : "orange";
 
     plt::plot(xs, ys);
-    plt::scatter(lmxs, lmys, {{"color", color}});
+    plt::scatter(lmxs, lmys, 1, {{"color", color}});
     plt::show();
 #endif
 
@@ -1149,7 +1149,7 @@ TEST(TestSuite, bearing_range_semantic_slam) {
   string color = (mpeClassL1 == 0) ? "b" : "orange";
 
   plt::plot(xs, ys);
-  plt::scatter(lmxs, lmys, {{"color", color}});
+  plt::scatter(lmxs, lmys, 1, {{"color", color}});
   plt::show();
 #endif
 
@@ -1302,7 +1302,7 @@ TEST(TestSuite, dcMaxMixture_semantic_slam) {
     string color = (mpeClassL1 == 0) ? "b" : "orange";
 
     plt::plot(xs, ys);
-    plt::scatter(lmxs, lmys, {{"color", color}});
+    plt::scatter(lmxs, lmys, 1, {{"color", color}});
     plt::show();
 #endif
 
@@ -1337,7 +1337,7 @@ TEST(TestSuite, dcMaxMixture_semantic_slam) {
   string color = (mpeClassL1 == 0) ? "b" : "orange";
 
   plt::plot(xs, ys);
-  plt::scatter(lmxs, lmys, {{"color", color}});
+  plt::scatter(lmxs, lmys, 1, {{"color", color}});
   plt::show();
 #endif
 
@@ -1485,7 +1485,7 @@ TEST(TestSuite, simple_dcemfactor) {
     string color = (mpeClassL1 == 0) ? "b" : "orange";
 
     plt::plot(xs, ys);
-    plt::scatter(lmxs, lmys, {{"color", color}});
+    plt::scatter(lmxs, lmys, 1, {{"color", color}});
     plt::show();
 #endif
 
@@ -1520,7 +1520,7 @@ TEST(TestSuite, simple_dcemfactor) {
   string color = (mpeClassL1 == 0) ? "b" : "orange";
 
   plt::plot(xs, ys);
-  plt::scatter(lmxs, lmys, {{"color", color}});
+  plt::scatter(lmxs, lmys, 1, {{"color", color}});
   plt::show();
 #endif
 

--- a/tests/testDCSAM.cpp
+++ b/tests/testDCSAM.cpp
@@ -16,7 +16,7 @@
 #include <gtsam/inference/BayesNet-inst.h>
 #include <gtsam/nonlinear/GaussNewtonOptimizer.h>
 #include <gtsam/nonlinear/Symbol.h>
-#include <gtsam/slam/BearingRangeFactor.h>
+#include <gtsam/sam/BearingRangeFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/PriorFactor.h>
 


### PR DESCRIPTION
mainly minor, readability changes

- Update to GTSAM 4.2a8 - pinning to a tagged version is perhaps better than a specific commit (required no changes)
- update flake8 url for pre-commit
- update README
- clean up CMakeLists.txt to conform with modern standards
- uses `FetchContent` cmake module to include matplotlibcpp as external project (cmake will clone the repo so the user doesn't have to install it globally)
- clean up plotting in tests
- remove `using namespace dcsam` from test -- being explicit makes it easier for a new user to differentiate between dcsam and gtsam APIs