### PR TITLE
Migrate CI to Github Actions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -20,7 +20,7 @@ jobs:
       run: docker build . --file Dockerfile --tag local
 
     - name: Build code
-      run: docker run -v $PWD:/work -w/work local /bin/bash -c "mkdir build && cd build && cmake -DENABLE_TESTS=ON .. && make -j8"
+      run: docker run -v $PWD:/work -w/work local /bin/bash -c "mkdir build && cd build && cmake -DDCSAM_ENABLE_TESTS=ON .. && make -j8"
 
     - name: Run tests
       run: docker run -v $PWD:/work -w/work local /bin/bash -c "cd build && make test"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,26 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build Docker image
+      run: docker build . --file Dockerfile --tag local
+
+    - name: Build code
+      run: docker run -v $PWD:/work -w/work local /bin/bash -c "mkdir build && cd build && cmake -DENABLE_TESTS=ON .. && make -j8"
+
+    - name: Run tests
+      run: docker run -v $PWD:/work -w/work local /bin/bash -c "cd build && make test"


### PR DESCRIPTION
This PR adds a Github Action for building the Dockerfile, compiling the code, and running the tests (i.e. all the CI stuff).

Thanks to @plusk01 for making this run smoothly!